### PR TITLE
using ApacheHttpClient4 too get rid of dependency to deprecated org.apache.commons.httpclient.HttpClient

### DIFF
--- a/hmac-auth-client/client.gradle
+++ b/hmac-auth-client/client.gradle
@@ -12,9 +12,8 @@ dependencies {
     compile 'joda-time:joda-time:1.6.2'
 
     compile 'org.slf4j:slf4j-api:1.6.1'
-    
-    compile 'com.sun.jersey.contribs:jersey-apache-client:1.17','com.sun.jersey:jersey-client:1.17','com.sun.jersey:jersey-core:1.17','commons-httpclient:commons-httpclient:3.1'
-    compile 'de.otto:hmac-auth-common:0.2.1-SNAPSHOT'
+
+    compile project(path: ":hmac-auth-common")
     
     testCompile 'org.testng:testng:6.3.1'
     testCompile 'org.hamcrest:hamcrest-core:1.3'

--- a/hmac-auth-client/src/main/java/de/otto/hmac/authentication/HMACJerseyClient.java
+++ b/hmac-auth-client/src/main/java/de/otto/hmac/authentication/HMACJerseyClient.java
@@ -1,20 +1,21 @@
 package de.otto.hmac.authentication;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.client.apache4.ApacheHttpClient4;
+import com.sun.jersey.client.apache4.ApacheHttpClient4Handler;
+import com.sun.jersey.client.apache4.config.DefaultApacheHttpClient4Config;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.joda.time.DateTime;
 import org.springframework.util.Assert;
-
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.client.apache.ApacheHttpClient;
-import com.sun.jersey.client.apache.ApacheHttpClientHandler;
-import com.sun.jersey.client.apache.config.DefaultApacheHttpClientConfig;
 
 import de.otto.hmac.HmacAttributes;
 import de.otto.hmac.StringUtils;
 
-public class HMACJerseyClient extends ApacheHttpClient {
+public class HMACJerseyClient extends ApacheHttpClient4 {
 
     private String user;
     private String secretKey;
@@ -24,7 +25,7 @@ public class HMACJerseyClient extends ApacheHttpClient {
     private String body = "";
 
     private HMACJerseyClient(final ClientConfig cc) {
-        super(createDefaultClientHander(cc), null);
+        super(createDefaultClientHandler(), cc, null);
     }
 
     public HMACJerseyClient auth(final String user, final String secretKey) {
@@ -53,14 +54,18 @@ public class HMACJerseyClient extends ApacheHttpClient {
         }
     }
 
-    private static ApacheHttpClientHandler createDefaultClientHander(final ClientConfig cc) {
-        final HttpClient client = new HttpClient(new MultiThreadedHttpConnectionManager());
+    private static ApacheHttpClient4Handler createDefaultClientHandler() {
+        final HttpClient client = new DefaultHttpClient(new ThreadSafeClientConnManager());
 
-        return new ApacheHttpClientHandler(client, cc);
+        return new ApacheHttpClient4Handler(client, createCookieStore(), false);
+    }
+
+    private static BasicCookieStore createCookieStore() {
+        return new BasicCookieStore();
     }
 
     public static HMACJerseyClient create() {
-        return create(new DefaultApacheHttpClientConfig());
+        return create(new DefaultApacheHttpClient4Config());
     }
 
     public static HMACJerseyClient create(final ClientConfig cc) {

--- a/hmac-auth-client/src/test/java/de/otto/hmac/authentication/HMACJerseyClientTest.java
+++ b/hmac-auth-client/src/test/java/de/otto/hmac/authentication/HMACJerseyClientTest.java
@@ -3,13 +3,11 @@ package de.otto.hmac.authentication;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.sun.jersey.client.apache.config.DefaultApacheHttpClientConfig;
-
 public class HMACJerseyClientTest {
 
     @Test
     public void shouldFailOnGetWithoutUser() {
-        final HMACJerseyClient client = HMACJerseyClient.create(new DefaultApacheHttpClientConfig());
+        final HMACJerseyClient client = HMACJerseyClient.create();
         try {
             client.withMethod("GET").withUri("testUri").auth(null, "key").authenticatedResource("/targetUri");
             Assert.fail("Exception expected");
@@ -28,7 +26,7 @@ public class HMACJerseyClientTest {
 
     @Test
     public void shouldFailOnGetWithoutSecret() {
-        final HMACJerseyClient client = HMACJerseyClient.create(new DefaultApacheHttpClientConfig());
+        final HMACJerseyClient client = HMACJerseyClient.create();
         try {
             client.withMethod("GET").withUri("testUri").auth("user", null).authenticatedResource("/targetUri");
             Assert.fail("Exception expected");
@@ -47,7 +45,7 @@ public class HMACJerseyClientTest {
 
     @Test
     public void shouldFailOnGetWithoutUri() {
-        final HMACJerseyClient client = HMACJerseyClient.create(new DefaultApacheHttpClientConfig());
+        final HMACJerseyClient client = HMACJerseyClient.create();
         try {
             client.withMethod("GET").auth("user", "secret").authenticatedResource("/targetUri");
             Assert.fail("Exception expected");
@@ -66,7 +64,7 @@ public class HMACJerseyClientTest {
 
     @Test
     public void shouldFailWithoutMethod() {
-        final HMACJerseyClient client = HMACJerseyClient.create(new DefaultApacheHttpClientConfig());
+        final HMACJerseyClient client = HMACJerseyClient.create();
         try {
             client.withUri("testUri").auth("user", "secret").authenticatedResource("/targetUri");
             Assert.fail("Exception expected");
@@ -85,7 +83,7 @@ public class HMACJerseyClientTest {
 
     @Test
     public void shouldFailOnPutWithoutBody() {
-        final HMACJerseyClient client = HMACJerseyClient.create(new DefaultApacheHttpClientConfig());
+        final HMACJerseyClient client = HMACJerseyClient.create();
         try {
             client.withMethod("PUT").withUri("testUri").auth("user", "secret").authenticatedResource("/targetUri");
             Assert.fail("Exception expected");
@@ -104,25 +102,25 @@ public class HMACJerseyClientTest {
 
     @Test
     public void shouldGetSuccessfulWithAllInformation() {
-        final HMACJerseyClient client = HMACJerseyClient.create(new DefaultApacheHttpClientConfig());
+        final HMACJerseyClient client = HMACJerseyClient.create();
         client.withMethod("GET").withUri("testUri").auth("user", "secret").authenticatedResource("/targetUri");
     }
 
     @Test
     public void shouldPutSuccessfulWithAllInformation() {
-        final HMACJerseyClient client = HMACJerseyClient.create(new DefaultApacheHttpClientConfig());
+        final HMACJerseyClient client = HMACJerseyClient.create();
         client.withMethod("PUT").withUri("testUri").withBody("body").auth("user", "secret").authenticatedResource("/targetUri");
     }
 
     @Test
     public void shouldPostSuccessfulWithAllInformation() {
-        final HMACJerseyClient client = HMACJerseyClient.create(new DefaultApacheHttpClientConfig());
+        final HMACJerseyClient client = HMACJerseyClient.create();
         client.withMethod("POST").withUri("testUri").withBody("body").auth("user", "secret").authenticatedResource("/targetUri");
     }
 
     @Test
     public void shouldDeleteSuccessfulWithAllInformation() {
-        final HMACJerseyClient client = HMACJerseyClient.create(new DefaultApacheHttpClientConfig());
+        final HMACJerseyClient client = HMACJerseyClient.create();
         client.withMethod("DELETE").withUri("testUri").auth("user", "secret").authenticatedResource("/targetUri");
     }
 }

--- a/hmac-auth-common/common.gradle
+++ b/hmac-auth-common/common.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     compile 'org.slf4j:slf4j-api:1.6.1'
     
-    compile 'com.sun.jersey.contribs:jersey-apache-client:1.9.1','com.sun.jersey:jersey-client:1.9.1','com.sun.jersey:jersey-core:1.9.1'
+    compile 'com.sun.jersey.contribs:jersey-apache-client4:1.9.1','com.sun.jersey:jersey-client:1.9.1','com.sun.jersey:jersey-core:1.9.1'
     
     testCompile 'org.testng:testng:6.3.1'
     testCompile 'org.hamcrest:hamcrest-core:1.3'

--- a/hmac-auth-proxy/proxy.gradle
+++ b/hmac-auth-proxy/proxy.gradle
@@ -7,7 +7,7 @@ targetCompatibility = 1.6
 
 
 dependencies {
-    compile 'de.otto:hmac-auth-client:0.2.1-SNAPSHOT'
+    compile project(path: ":hmac-auth-client")
 
     compile "com.sun.jersey:jersey-server:1.17"
     compile "com.sun.jersey:jersey-core:1.17"

--- a/hmac-auth-proxy/src/main/java/de/otto/hmac/proxy/ProxyResource.java
+++ b/hmac-auth-proxy/src/main/java/de/otto/hmac/proxy/ProxyResource.java
@@ -2,7 +2,6 @@ package de.otto.hmac.proxy;
 
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.client.apache.config.DefaultApacheHttpClientConfig;
 import de.otto.hmac.authentication.HMACJerseyClient;
 
 import javax.ws.rs.*;
@@ -121,7 +120,7 @@ public class ProxyResource {
 
     protected WebResource.Builder webResourceWithAuth(String body, String method, URI targetUri) {
         WebResource.Builder builder = HMACJerseyClient
-                .create(new DefaultApacheHttpClientConfig())
+                .create()
                 .withMethod(method)
                 .withUri(targetUri.getPath())
                 .withBody(body)

--- a/hmac-auth-proxy/src/test/java/de/otto/hmac/proxy/ProxyResourceTest.java
+++ b/hmac-auth-proxy/src/test/java/de/otto/hmac/proxy/ProxyResourceTest.java
@@ -1,15 +1,12 @@
 package de.otto.hmac.proxy;
 
-import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.client.apache.ApacheHttpClient;
 import com.sun.jersey.client.impl.ClientRequestImpl;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 


### PR DESCRIPTION
Hi,

ich habe mir die Mühe gemacht die Abhängigkeiten zu dem längst deprecateten `org.apache.commons.httpclient` Packages auszubauen.

Schaut mal bitte genau auf die compile-Abhängigkeiten in den verschiedenen `*.gradle` Dateien der Subprojekte. Es kann sein, dass die von mir gewählte Notation:

```
compile project(path: ":subproject")
```

nicht für die verteilung über MavenCentral und so geeignet ist. Dann müssen da wieder echte Versionsnummern genutzt werden.
