### PR TITLE
Refactored .trim() to method

### DIFF
--- a/hmac-auth-common/src/main/java/de/otto/hmac/authentication/RequestSigningUtil.java
+++ b/hmac-auth-common/src/main/java/de/otto/hmac/authentication/RequestSigningUtil.java
@@ -32,7 +32,7 @@ public class RequestSigningUtil {
         final String[] split = requestSignature.split(":");
         final String sentSignature = split[1];
 
-        final String generatedSignature = createRequestSignature(request, secretKey).trim();
+        final String generatedSignature = createRequestSignature(request, secretKey);
 
         return generatedSignature.equals(sentSignature);
     }
@@ -84,7 +84,7 @@ public class RequestSigningUtil {
             mac.init(keySpec);
             final String signatureBase = createSignatureBase(method, dateHeader, requestUri, body);
             final byte[] result = mac.doFinal(signatureBase.getBytes());
-            return Base64.encodeBase64String(result);
+            return encodeBase64WithoutLinefeed(result);
 
         }
         catch (final Exception e) {
@@ -99,11 +99,15 @@ public class RequestSigningUtil {
             mac.init(keySpec);
             final String signatureBase = createSignatureBase(request);
             final byte[] result = mac.doFinal(signatureBase.getBytes());
-            return Base64.encodeBase64String(result);
+            return encodeBase64WithoutLinefeed(result);
         }
         catch (final Exception e) {
             throw new RuntimeException("should never happen", e);
         }
+    }
+
+    protected static String encodeBase64WithoutLinefeed(byte[] result) {
+        return Base64.encodeBase64String(result).trim();
     }
 
     private static String toMd5(final String body) {


### PR DESCRIPTION
The falsy behaviour derives from two different apache-common versions, (1.4 vs 1.7) where the older one has multi-line chunking and the newer single-line non-chunking. This is hard to test and will not be tested as agreed upon with Tom Vollerthun
