### PR TITLE
Do not expose names of existing security groups when user requests are unauthorised

### DIFF
--- a/hmac-auth-server/src/main/java/de/otto/hmac/authorization/AuthorizationException.java
+++ b/hmac-auth-server/src/main/java/de/otto/hmac/authorization/AuthorizationException.java
@@ -1,8 +1,13 @@
 package de.otto.hmac.authorization;
 
+import static java.lang.String.format;
+
 public class AuthorizationException extends RuntimeException {
 
+    private static final String errorMessage = "%s is not in one of the required security groups.";
+
     public AuthorizationException(String message) {
-        super(message);
+        super(format(errorMessage, message));
     }
+
 }

--- a/hmac-auth-server/src/test/java/de/otto/hmac/authorization/DefaultAuthorizationServiceTest.java
+++ b/hmac-auth-server/src/test/java/de/otto/hmac/authorization/DefaultAuthorizationServiceTest.java
@@ -143,7 +143,7 @@ public class DefaultAuthorizationServiceTest {
             authComponent("").authorize("", roles);
             fail("Should not authorize if user is not in Group");
         } catch (AuthorizationException e) {
-            assertThat(e.getMessage(), is("Anonymous user is not in one of these groups: [admin, shopoffice]."));
+            assertThat(e.getMessage(), is("[Anonymous user] is not in one of the required security groups."));
         }
     }
 
@@ -154,7 +154,7 @@ public class DefaultAuthorizationServiceTest {
             authComponent("someUnauthorizedUser").authorize("someUnauthorizedUser", roles);
             fail("Should not authorize if user is not in Group");
         } catch (AuthorizationException e) {
-            assertThat(e.getMessage(), is("[someUnauthorizedUser] is not in one of these groups: [admin, shopoffice]."));
+            assertThat(e.getMessage(), is("[someUnauthorizedUser] is not in one of the required security groups."));
         }
     }
 

--- a/hmac-auth-server/src/test/java/de/otto/hmac/authorization/FileSystemUserRepositoryTest.java
+++ b/hmac-auth-server/src/test/java/de/otto/hmac/authorization/FileSystemUserRepositoryTest.java
@@ -1,17 +1,16 @@
 package de.otto.hmac.authorization;
 
 import de.otto.hmac.FileSystemUserRepository;
-import org.springframework.core.io.ClassPathResource;
 import org.testng.annotations.Test;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 
 @Test


### PR DESCRIPTION
Hello, 

This pull request is to ensure that the names of security groups are not exposed to the outside world in the form of a HTTP response, when a user request is unauthorised. 

This information is now logged to the log file and a simpler, less detailed error messaged is returned to the client, exposing less of the server's internal state. 

Matt
