### PR TITLE
jdk11 compatibility implemented for hmac proxy

### DIFF
--- a/hmac-auth-proxy/proxy.gradle
+++ b/hmac-auth-proxy/proxy.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     compile "com.sun.jersey:jersey-server:1.18.1"
     compile "com.sun.jersey:jersey-grizzly2:1.18.1"
-
+    compile "javax.xml.bind:jaxb-api:2.3.1"
     compile "com.beust:jcommander:1.35"
 
     runtime "org.slf4j:slf4j-log4j12:1.7.7"


### PR DESCRIPTION
jdk/jre 11 does not contain jaxb in comparison to jdk8. Accordingly, jaxb is needed as a dependency for the hmac proxy so that i can be run with jre11. This commit also includes the distribution built including the new jaxb dependency. 