### PR TITLE
Proxy jdk11 compatibility

### DIFF
--- a/hmac-auth-proxy/proxy.gradle
+++ b/hmac-auth-proxy/proxy.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'application'
+apply plugin: "application"
 
 mainClassName = "de.otto.hmac.proxy.ProxyServer"
 
@@ -11,14 +11,17 @@ dependencies {
 
     compile "com.sun.jersey:jersey-server:1.18.1"
     compile "com.sun.jersey:jersey-grizzly2:1.18.1"
-    compile "javax.xml.bind:jaxb-api:2.3.1"
+    compile "javax.xml.bind:jaxb-api:2.3.0"
+    compile "com.sun.xml.bind:jaxb-impl:2.3.0"
+    compile "com.sun.xml.bind:jaxb-core:2.3.0"
+    compile "javax.activation:activation:1.1.1"
     compile "com.beust:jcommander:1.35"
 
     runtime "org.slf4j:slf4j-log4j12:1.7.7"
 
-    testCompile 'org.testng:testng:6.8.8'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.mockito:mockito-core:1.9.5'
+    testCompile "org.testng:testng:6.8.8"
+    testCompile "org.hamcrest:hamcrest-library:1.3"
+    testCompile "org.mockito:mockito-core:1.9.5"
 }
 
 artifacts {
@@ -38,33 +41,33 @@ uploadArchives {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
             pom.project {
-                name 'hmac-auth-proxy'
-                packaging 'distZip'
-                description 'Proxy-Application of the hmac-auth project.'
-                url 'http://github.com/otto-de/hmac-auth'
+                name "hmac-auth-proxy"
+                packaging "distZip"
+                description "Proxy-Application of the hmac-auth project."
+                url "http://github.com/otto-de/hmac-auth"
 
                 scm {
-                    url 'scm:git@github.com:otto-de/hmac-auth.git'
-                    connection 'scm:git@github.com:otto-de/hmac-auth.git'
-                    developerConnection 'scm:git@github.com:otto-de/hmac-auth.git'
+                    url "scm:git@github.com:otto-de/hmac-auth.git"
+                    connection "scm:git@github.com:otto-de/hmac-auth.git"
+                    developerConnection "scm:git@github.com:otto-de/hmac-auth.git"
                 }
 
                 licenses {
                     license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution 'repo'
+                        name "The Apache Software License, Version 2.0"
+                        url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                        distribution "repo"
                     }
                 }
 
                 developers {
                     developer {
-                        id 'tvollert'
-                        name 'Tom Vollerthun'
+                        id "tvollert"
+                        name "Tom Vollerthun"
                     }
                     developer {
-                        id 'drolfes'
-                        name 'Daniel Rolfes'
+                        id "drolfes"
+                        name "Daniel Rolfes"
                     }
                 }
             }


### PR DESCRIPTION
it turned out that the jaxb api library added before is only the jax api and an implementation needs to be included with it. I added the implementation libraries accordingly and additionally i built the binary again that includes the new libraries. For more information, please refer to this stackoverflow thread: https://stackoverflow.com/a/43574427.