### PR TITLE
Log authentication failures as WARN, not ERROR

### DIFF
--- a/hmac-auth-server/src/main/java/de/otto/hmac/authentication/AuthenticationFilter.java
+++ b/hmac-auth-server/src/main/java/de/otto/hmac/authentication/AuthenticationFilter.java
@@ -38,7 +38,7 @@ public class AuthenticationFilter implements Filter {
 
                 if (result.getStatus() == FAIL) {
                     httpResponse.sendError(SC_UNAUTHORIZED);
-                    LOG.error("Validierung der Signatur fehlgeschlagen.");
+                    LOG.warn("Validierung der Signatur fehlgeschlagen.");
                     return;
                 }
 


### PR DESCRIPTION
Co-authored-by: @aidamanna2222

Hi there,

we were seeing errors in our logs tracing back to authentication failures in the hmac auth server. If we understand, this situation is expected, and means that a user tried to authenticate but was unauthorized. Is that correct? If so, as it's an expected outcome of the operation, what do you think about not logging it as an error? As there is nothing a human can do about it.

Cheers,
Aida and Klaus