### PR TITLE
Update build.gradle to deal with deprecation warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ subprojects {
 
     sourceCompatibility = 17
 
+    compileJava {
+        options.compilerArgs << '-parameters'
+    }
+
     repositories {
         mavenCentral()
         mavenLocal()


### PR DESCRIPTION
"loggerName": "org.springframework.core.LocalVariableTableParameterNameDiscoverer",

    "message": "Using deprecated '-debug' fallback for parameter name resolution. Compile the affected code with '-parameters' instead or avoid its introspection: de.otto.hmac.authorization.RolesAuthorizationAspect